### PR TITLE
feat: Add session selection menu for modules

### DIFF
--- a/rpo-training/index.html
+++ b/rpo-training/index.html
@@ -44,12 +44,12 @@
                     </div>
                 </div>
                 <div class="mt-8 grid md:grid-cols-2 gap-6">
-                    <div class="module-card" onclick="navigateTo('session-1-1-page')">
+                    <div class="module-card" onclick="navigateTo('module-1')">
                         <p class="text-sm font-semibold text-blue-600">MODULE 1</p>
                         <h3 class="google-sans text-xl font-bold mt-2">Prompting &amp; Writing — The C.R.E.A.T.E. Framework</h3>
                         <p class="mt-2 text-gray-600">Learn the C.R.E.A.T.E. framework — a structured approach (Character, Request, Examples, Additions, Type, Extras) for crafting precise, repeatable, high-quality prompts.</p>
                     </div>
-                    <div class="module-card" onclick="navigateTo('session-2-1-page')">
+                    <div class="module-card" onclick="navigateTo('module-2')">
                         <p class="text-sm font-semibold text-blue-600">MODULE 2</p>
                         <h3 class="google-sans text-xl font-bold mt-2">Sourcing & Research</h3>
                         <p class="mt-2 text-gray-600">Generate complex Boolean strings and perform rapid market analysis.</p>
@@ -70,17 +70,17 @@
                     </div>
                 </div>
                 <div class="mt-8 grid md:grid-cols-3 gap-6">
-                    <div class="module-card" onclick="navigateTo('session-3-1-page')">
+                    <div class="module-card" onclick="navigateTo('module-3')">
                         <p class="text-sm font-semibold text-green-600">MODULE 3</p>
                         <h3 class="google-sans text-xl font-bold mt-2">Data & Knowledge</h3>
                         <p class="mt-2 text-gray-600">Analyze data in Sheets and build a "CV Bot" to search documents.</p>
                     </div>
-                    <div class="module-card" onclick="navigateTo('session-4-1-page')">
+                    <div class="module-card" onclick="navigateTo('module-4')">
                         <p class="text-sm font-semibold text-green-600">MODULE 4</p>
                         <h3 class="google-sans text-xl font-bold mt-2">Automation</h3>
                         <p class="mt-2 text-gray-600">Build hands-free workflows that connect Gmail, AI, and Sheets.</p>
                     </div>
-                    <div class="module-card" onclick="navigateTo('session-5-1-page')">
+                    <div class="module-card" onclick="navigateTo('module-5')">
                         <p class="text-sm font-semibold text-green-600">MODULE 5</p>
                         <h3 class="google-sans text-xl font-bold mt-2">Train the Trainer</h3>
                         <p class="mt-2 text-gray-600">Learn to mentor colleagues and present your projects to leadership.</p>
@@ -101,12 +101,12 @@
                     </div>
                 </div>
                 <div class="mt-8 grid md:grid-cols-2 gap-6">
-                    <div class="module-card" onclick="navigateTo('session-6-1-page')">
+                    <div class="module-card" onclick="navigateTo('module-6')">
                         <p class="text-sm font-semibold text-purple-600">MODULE 6</p>
                         <h3 class="google-sans text-xl font-bold mt-2">Strategy & Governance</h3>
                         <p class="mt-2 text-gray-600">Develop an RPO-specific AI roadmap and prioritize high-impact projects.</p>
                     </div>
-                    <div class="module-card" onclick="navigateTo('session-7-1-page')">
+                    <div class="module-card" onclick="navigateTo('module-7')">
                         <p class="text-sm font-semibold text-purple-600">MODULE 7</p>
                         <h3 class="google-sans text-xl font-bold mt-2">Measuring Impact</h3>
                         <p class="mt-2 text-gray-600">Define success metrics and build a compelling business case for AI projects.</p>

--- a/rpo-training/js/app.js
+++ b/rpo-training/js/app.js
@@ -4,6 +4,16 @@ document.addEventListener('DOMContentLoaded', () => {
     const headerTitle = document.getElementById('header-title');
     const copyrightYear = document.getElementById('copyright-year');
 
+    const moduleTitles = {
+        'module-1': 'Module 1: Prompting & Writing — The C.R.E.A.T.E. Framework',
+        'module-2': 'Module 2: Sourcing & Research',
+        'module-3': 'Module 3: Data & Knowledge',
+        'module-4': 'Module 4: Automation',
+        'module-5': 'Module 5: Train the Trainer',
+        'module-6': 'Module 6: Strategy & Governance',
+        'module-7': 'Module 7: Measuring Impact'
+    };
+
     const pageTitles = {
         'main-page': 'RPO AI Acceleration Program',
         'session-1-1-page': 'Session 1.1: Prompt Engineering 101',
@@ -20,6 +30,44 @@ document.addEventListener('DOMContentLoaded', () => {
         'session-6-1-page': 'Session 6.1: Developing an AI Roadmap',
         'session-7-1-page': 'Session 7.1: The ROI of AI in Recruiting'
     };
+
+    function showSessionMenu(moduleId) {
+        const moduleNum = moduleId.split('-')[1];
+        const sessions = Object.keys(pageTitles)
+            .filter(key => key.startsWith(`session-${moduleNum}-`))
+            .map(key => ({
+                id: key,
+                title: pageTitles[key]
+            }));
+
+        let menuHtml = `
+            <div class="content-section">
+                <button onclick="navigateTo('main-page')" class="mb-4 inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
+                    &larr; Back to All Modules
+                </button>
+                <h2 class="google-sans text-3xl font-bold text-gray-800">${moduleTitles[moduleId]}</h2>
+                <p class="mt-2 text-lg text-gray-600">Select a session to begin.</p>
+                <ul class="mt-6 space-y-4">
+        `;
+
+        sessions.forEach(session => {
+            menuHtml += `
+                <li>
+                    <a href="#" onclick="event.preventDefault(); navigateTo('${session.id}')" class="block bg-white p-6 rounded-lg shadow-md hover:bg-gray-50 transition">
+                        <h3 class="google-sans text-xl font-bold text-blue-700">${session.title}</h3>
+                    </a>
+                </li>
+            `;
+        });
+
+        menuHtml += '</ul></div>';
+
+        sessionContainer.innerHTML = menuHtml;
+        sessionContainer.classList.add('active');
+        mainPage.classList.remove('active');
+        headerTitle.textContent = moduleTitles[moduleId] || 'Select a Session';
+        window.scrollTo(0, 0);
+    }
 
     function navigateTo(pageId) {
         if (pageId !== 'main-page') {
@@ -38,6 +86,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 window.scrollTo(0, parseInt(savedPosition, 10));
                 sessionStorage.removeItem('scrollPosition');
             }
+        } else if (pageId.startsWith('module-')) {
+            showSessionMenu(pageId);
         } else {
             const sessionPath = pageId.replace('session-', '').replace('-page', '');
             const filePath = `sessions/${sessionPath}.html`;


### PR DESCRIPTION
I've implemented an intermediate session selection page that appears when you click on a module.

Previously, clicking a module would navigate directly to the first session. Now, a dynamically generated menu shows all available sessions for that module, allowing you to choose.

I implemented this new flow by:
- Updating onclick handlers in `index.html` to pass a module identifier.
- Adding a new `showSessionMenu` function in `app.js` to generate and display the menu.
- Modifying the `navigateTo` function to handle the new module identifiers.